### PR TITLE
docs: unify project naming

### DIFF
--- a/lib/core/widgets/custom_app_bar.dart
+++ b/lib/core/widgets/custom_app_bar.dart
@@ -38,7 +38,7 @@ class CustomAppBar extends StatelessWidget implements PreferredSizeWidget {
             ],
           ).createShader(bounds),
           child: Text(
-            'DNTU Focus',
+            'DNTU-Focus',
             style: Theme.of(context).textTheme.titleLarge?.copyWith(
               fontSize: 24,
               fontWeight: FontWeight.bold,

--- a/lib/features/auth/presentation/login_screen.dart
+++ b/lib/features/auth/presentation/login_screen.dart
@@ -94,7 +94,7 @@ class _LoginScreenState extends State<LoginScreen> {
         ),
         const SizedBox(height: 24),
         Text(
-          'DNTU - Focus',
+          'DNTU-Focus',
           style: textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.bold),
         ),
       ],


### PR DESCRIPTION
## Summary
- revert prior renaming to moji_todo
- show consistent **DNTU-Focus** branding in login and app bar

## Testing
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684a79d084248333a3dd652b44514d86