### PR TITLE
test: add initial Flutter test suite

### DIFF
--- a/.github/workflows/flutter_test.yml
+++ b/.github/workflows/flutter_test.yml
@@ -1,0 +1,17 @@
+name: Flutter Test
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+      - run: flutter pub get
+      - run: flutter test

--- a/README.md
+++ b/README.md
@@ -182,6 +182,11 @@ Sắp xếp công việc với dự án và thẻ, đồng bộ qua Firestore.
    flutter run
    ```
 
+5. **Chạy kiểm thử**:
+   ```bash
+   flutter test
+   ```
+
 ## Kiến trúc
 
 ### Công nghệ

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('renders hello text', (WidgetTester tester) async {
+    await tester.pumpWidget(const MaterialApp(
+      home: Scaffold(body: Text('Hello')),
+    ));
+
+    expect(find.text('Hello'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- add `test/widget_test.dart`
- document how to run `flutter test`
- run tests in CI with GitHub Actions

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684a7a0af3948333a138f4421584e357